### PR TITLE
Support '-a' option

### DIFF
--- a/04.ls/lib/ls_methods.rb
+++ b/04.ls/lib/ls_methods.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
-def child_files(fpath)
-  Dir.children(fpath)
-     .sort
-     .reject { |child| dot_file?(child) }
+def child_files(fpath, export_all: false)
+  if export_all
+    Dir.entries(fpath)
+  else
+    Dir.children(fpath)
+       .reject { |child| dot_file?(child) }
+  end.sort
 end
 
 def dot_file?(fname)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,5 +2,8 @@
 # frozen_string_literal: true
 
 require_relative './lib/ls_methods'
+require 'optparse'
 
-table_print(child_files('.'), 3)
+opts = ARGV.getopts('a')
+
+table_print(child_files('.', export_all: opts['a']), 3)


### PR DESCRIPTION
* 04.ls/lib/ls_methods.rb (#child_files): Add 'export_all' keyword parameter.

* 04.ls/ls.rb: Get '-a' option from ARGV.