### PR TITLE
Support '-r' option

### DIFF
--- a/04.ls/lib/ls_methods.rb
+++ b/04.ls/lib/ls_methods.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-def child_files(fpath)
+def child_files(fpath, reverse_order: false)
   Dir.children(fpath)
-     .sort
+     .sort { |a, z| reverse_order ? z <=> a : a <=> z }
      .reject { |child| dot_file?(child) }
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,5 +2,8 @@
 # frozen_string_literal: true
 
 require_relative './lib/ls_methods'
+require 'optparse'
 
-table_print(child_files('.'), 3)
+opts = ARGV.getopts('r')
+
+table_print(child_files('.', reverse_order: opts['r']), 3)


### PR DESCRIPTION
* 04.ls/lib/ls_method.rb (#child_files): Add 'reverse_order' keyword parameter.

* 04.ls/ls.rb: Get '-r' option from ARGV.